### PR TITLE
Remove incorrect checking of DocType DTD URIs

### DIFF
--- a/bin/checklink
+++ b/bin/checklink
@@ -2292,9 +2292,6 @@ sub declaration
             # Store the doctype
             $self->doctype($1) if $1;
 
-            # If there is a link to the DTD, record it
-            $self->add_link($3, undef, $line, MC_NONE)
-                if (!$self->{only_anchors} && $3);
         }
     }
 


### PR DESCRIPTION
For a brief time (some decades), the DTD URIs found in DocType declarations could be interpreted as URLs. This is no longer the case since the W3C has removed the resources at those locations (e.g. `http://www.w3.org/TR/html4/strict.dtd` no longer returns 200). The link-checker should not attempt to check DTD URIs, since they are identifiers, not necessarily locations.